### PR TITLE
Allow NODE_ENV value to be set in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY --chown=1001 . .
 RUN npm install && \
     npm run compile
 
-ENV HOST=0.0.0.0 PORT=3001
+ENV NODE_ENV=staging HOST=0.0.0.0 PORT=3001
 
 EXPOSE ${PORT}
 CMD ["npm", "run", "serve"]

--- a/package.json
+++ b/package.json
@@ -38,9 +38,10 @@
     "start:dev": "NODE_ENV=dev node -r source-map-support/register .",
     "clean": "lb-clean dist *.tsbuildinfo .eslintcache",
     "rebuild": "npm run clean && npm run compile",
-    "serve": "NODE_ENV=staging node .",
+    "serve": "node .",
     "serve:dev": "NODE_ENV=dev node .",
     "serve:test": "NODE_ENV=test node .",
+    "serve:staging": "NODE_ENV=staging node .",
     "scan": "detect-secrets scan --update .secrets.baseline --exclude-files 'package-lock.json'"
   },
   "repository": {


### PR DESCRIPTION
- remove NODE_ENV argument from serve script and move to Dockerfile so that it can be overridden at deploy time